### PR TITLE
fix(auth): restrict course search to user-enrolled courses (fail-closed)

### DIFF
--- a/proxy/src/application/useCases/chat/streamChat.js
+++ b/proxy/src/application/useCases/chat/streamChat.js
@@ -133,9 +133,17 @@ export async function streamChat({
     ? await resolveUserProfile(userId, userRepository)
     : createUserProfile({ id: userId ?? 0, courses: [] });
 
+  // Restrict course search to courses the user is actually enrolled in. searchCourses
+  // is fail-closed: an empty or omitted `allowedIds` is treated as "no authorized
+  // courses" and short-circuits to found:false, so the filter below is the only
+  // place where authorization intent lives.
+  const allowedIds = (userProfile.courses ?? [])
+    .filter((c) => Number.isInteger(c.id) && c.id > 0)
+    .map((c) => c.id);
+
   const [historySettled, searchSettled] = await Promise.allSettled([
     chatRepository.getHistory(sessionId, 12),
-    searchCourses({ query: message, courseRepository }),
+    searchCourses({ query: message, courseRepository, allowedIds }),
   ]);
 
   const historyArray = historySettled.status === "fulfilled" ? historySettled.value : [];

--- a/proxy/src/application/useCases/courses/searchCourses.js
+++ b/proxy/src/application/useCases/courses/searchCourses.js
@@ -121,12 +121,17 @@ function extractQuotedPhrases(text) {
 }
 
 export async function searchCourses({ query, courseRepository, allowedIds }) {
+  // Fail-closed authorization: callers must explicitly enumerate the courses
+  // the user is allowed to see. Omitting or emptying `allowedIds` means the
+  // user has no authorized courses, so we never touch the repository and never
+  // leak any course contents.
+  if (!Array.isArray(allowedIds) || allowedIds.length === 0) {
+    return { found: false, message: "Course not found" };
+  }
+
   try {
     const allCourses = await courseRepository.getAllCourses();
-    const courses =
-      Array.isArray(allowedIds) && allowedIds.length
-        ? allCourses.filter((c) => allowedIds.includes(c.id))
-        : allCourses;
+    const courses = allCourses.filter((c) => allowedIds.includes(c.id));
 
     const tokens = tokenize(query);
     const phrases = extractQuotedPhrases(query);

--- a/proxy/tests/unit/useCases/searchCourses.test.js
+++ b/proxy/tests/unit/useCases/searchCourses.test.js
@@ -4,44 +4,76 @@ import { searchCourses } from "../../../src/application/useCases/courses/searchC
 import { mockCourses } from "../../fixtures/mockCourseData.js";
 import { buildMockCourseRepository } from "../../fixtures/mockRepositories.js";
 
+// All ids in the mock fixture — used to simulate a user enrolled in every course.
+// searchCourses is now fail-closed: any call without an explicit `allowedIds`
+// returns { found: false, message: "Course not found" } without touching the
+// repository. Tests that exercise ranking/contents pass `allowedIds: allIds`
+// to bypass the authorization gate while keeping the rest of the behavior
+// under test.
+const allIds = mockCourses.map((c) => c.id);
+
 test("exact match by course name returns LF07", async () => {
   const repo = buildMockCourseRepository(mockCourses);
-  const result = await searchCourses({ query: "lf07", courseRepository: repo });
+  const result = await searchCourses({
+    query: "lf07",
+    courseRepository: repo,
+    allowedIds: allIds,
+  });
   assert.strictEqual(result.found, true);
   assert.strictEqual(result.course.name, "LF07 Netzwerktechnik");
 });
 
 test("match by shortname returns WP212", async () => {
   const repo = buildMockCourseRepository(mockCourses);
-  const result = await searchCourses({ query: "wp212", courseRepository: repo });
+  const result = await searchCourses({
+    query: "wp212",
+    courseRepository: repo,
+    allowedIds: allIds,
+  });
   assert.strictEqual(result.found, true);
   assert.strictEqual(result.course.name, "WP212 Webprogrammierung");
 });
 
 test("nonexistent query returns found false", async () => {
   const repo = buildMockCourseRepository(mockCourses);
-  const result = await searchCourses({ query: "xyznonexistent", courseRepository: repo });
+  const result = await searchCourses({
+    query: "xyznonexistent",
+    courseRepository: repo,
+    allowedIds: allIds,
+  });
   assert.strictEqual(result.found, false);
   assert.strictEqual(result.message, "Course not found");
 });
 
 test("quoted query performs phrase match", async () => {
   const repo = buildMockCourseRepository(mockCourses);
-  const result = await searchCourses({ query: '"Netzwerktechnik"', courseRepository: repo });
+  const result = await searchCourses({
+    query: '"Netzwerktechnik"',
+    courseRepository: repo,
+    allowedIds: allIds,
+  });
   assert.strictEqual(result.found, true);
   assert.strictEqual(result.course.name, "LF07 Netzwerktechnik");
 });
 
 test("number in query boosts shortname match", async () => {
   const repo = buildMockCourseRepository(mockCourses);
-  const result = await searchCourses({ query: "07", courseRepository: repo });
+  const result = await searchCourses({
+    query: "07",
+    courseRepository: repo,
+    allowedIds: allIds,
+  });
   assert.strictEqual(result.found, true);
   assert.strictEqual(result.course.name, "LF07 Netzwerktechnik");
 });
 
 test("empty query returns found false without crashing", async () => {
   const repo = buildMockCourseRepository(mockCourses);
-  const result = await searchCourses({ query: "", courseRepository: repo });
+  const result = await searchCourses({
+    query: "",
+    courseRepository: repo,
+    allowedIds: allIds,
+  });
   assert.strictEqual(result.found, false);
   assert.strictEqual(result.message, "Course not found");
 });
@@ -70,7 +102,11 @@ test("allowedIds includes matching course", async () => {
 
 test("returns course sections when course is found", async () => {
   const repo = buildMockCourseRepository(mockCourses);
-  const result = await searchCourses({ query: "lf07", courseRepository: repo });
+  const result = await searchCourses({
+    query: "lf07",
+    courseRepository: repo,
+    allowedIds: allIds,
+  });
   assert.strictEqual(result.found, true);
   assert.ok(Array.isArray(result.sections));
   assert.strictEqual(result.sections.length, 2);
@@ -84,7 +120,11 @@ test("course search unavailable when getCourseContents throws", async () => {
       throw new Error("Timeout");
     },
   };
-  const result = await searchCourses({ query: "lf07", courseRepository: repo });
+  const result = await searchCourses({
+    query: "lf07",
+    courseRepository: repo,
+    allowedIds: allIds,
+  });
   assert.strictEqual(result.found, false);
   assert.strictEqual(result.message, "Course search unavailable");
 });
@@ -95,7 +135,11 @@ test("course search unavailable when repository throws", async () => {
       throw new Error("DB error");
     },
   };
-  const result = await searchCourses({ query: "lf07", courseRepository: repo });
+  const result = await searchCourses({
+    query: "lf07",
+    courseRepository: repo,
+    allowedIds: allIds,
+  });
   assert.strictEqual(result.found, false);
   assert.strictEqual(result.message, "Course search unavailable");
 });
@@ -117,14 +161,22 @@ test("MAX_SECTIONS_IN_RESPONSE limits returned sections", async () => {
     },
   ];
   const repo = buildMockCourseRepository(courses);
-  const result = await searchCourses({ query: "lf99", courseRepository: repo });
+  const result = await searchCourses({
+    query: "lf99",
+    courseRepository: repo,
+    allowedIds: [99],
+  });
   assert.strictEqual(result.found, true);
   assert.strictEqual(result.sections.length, 3); // MAX_SECTIONS_IN_RESPONSE
 });
 
 test("stop words are ignored in query", async () => {
   const repo = buildMockCourseRepository(mockCourses);
-  const result = await searchCourses({ query: "lf07 und netzwerk", courseRepository: repo });
+  const result = await searchCourses({
+    query: "lf07 und netzwerk",
+    courseRepository: repo,
+    allowedIds: allIds,
+  });
   assert.strictEqual(result.found, true);
   assert.strictEqual(result.course.name, "LF07 Netzwerktechnik");
 });
@@ -144,9 +196,51 @@ test("fallback returns all sections when no token-matching sections", async () =
     },
   ];
   const repo = buildMockCourseRepository(courses);
-  const result = await searchCourses({ query: "lf10", courseRepository: repo });
+  const result = await searchCourses({
+    query: "lf10",
+    courseRepository: repo,
+    allowedIds: [10],
+  });
   assert.strictEqual(result.found, true);
   assert.strictEqual(result.sections.length, 2);
   assert.strictEqual(result.sections[0].name, "Alpha");
   assert.strictEqual(result.sections[1].name, "Beta");
+});
+
+// --- Fail-closed authorization (searchCourses enforces allowedIds) ---
+
+test("searchCourses returns found false when allowedIds is omitted", async () => {
+  // No repository mock is needed: the fail-closed short-circuit must return
+  // before any repository call, proving authorization is enforced at the
+  // function boundary, not by the caller.
+  const result = await searchCourses({
+    query: "lf07",
+    courseRepository: {
+      getAllCourses: async () => {
+        throw new Error("repository must not be called when allowedIds is missing");
+      },
+      getCourseContents: async () => {
+        throw new Error("repository must not be called when allowedIds is missing");
+      },
+    },
+  });
+  assert.strictEqual(result.found, false);
+  assert.strictEqual(result.message, "Course not found");
+});
+
+test("searchCourses returns found false when allowedIds is empty", async () => {
+  const result = await searchCourses({
+    query: "lf07",
+    courseRepository: {
+      getAllCourses: async () => {
+        throw new Error("repository must not be called when allowedIds is empty");
+      },
+      getCourseContents: async () => {
+        throw new Error("repository must not be called when allowedIds is empty");
+      },
+    },
+    allowedIds: [],
+  });
+  assert.strictEqual(result.found, false);
+  assert.strictEqual(result.message, "Course not found");
 });

--- a/proxy/tests/unit/useCases/streamChat.test.js
+++ b/proxy/tests/unit/useCases/streamChat.test.js
@@ -1,0 +1,208 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import { streamChat } from "../../../src/application/useCases/chat/streamChat.js";
+
+// LLM mock: yields a single NDJSON line with `done: true` so streamChat's outer
+// loop exits immediately without writing any assistant reply.
+function makeDoneStream() {
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode('{"done":true}\n'));
+      controller.close();
+    },
+  });
+}
+
+function makeNoopAppendMessage() {
+  return async () => {};
+}
+
+function makeNoopGetHistory() {
+  return async () => [];
+}
+
+function makeLlmService() {
+  return {
+    streamResponse: async () => makeDoneStream(),
+  };
+}
+
+function makeChatRepository() {
+  return {
+    getHistory: makeNoopGetHistory(),
+    appendMessage: makeNoopAppendMessage(),
+    clearSession: async () => {},
+  };
+}
+
+function makeUserRepository({ info, courses, fail } = {}) {
+  if (fail) {
+    return {
+      getUserInfo: async () => {
+        throw new Error("moodle down");
+      },
+      getUserCourses: async () => {
+        throw new Error("moodle down");
+      },
+    };
+  }
+  return {
+    getUserInfo: async (id) => info ?? { id, firstname: "Max", lastname: "Mustermann" },
+    getUserCourses: async () => courses ?? [],
+  };
+}
+
+function makeCourseRepository() {
+  // streamChat never invokes this directly; searchCourses is mocked as a plain
+  // function so the LLM flow does not touch the real repository.
+  return {
+    getAllCourses: async () => [],
+    getCourseContents: async () => [],
+  };
+}
+
+test("streamChat passes userProfile course ids to searchCourses as allowedIds", async () => {
+  const userRepository = makeUserRepository({
+    courses: [
+      { id: 5, name: "LF07", shortname: "LF07" },
+      { id: 12, name: "LF08", shortname: "LF08" },
+    ],
+  });
+  const observed = [];
+  const searchCourses = async (args) => {
+    observed.push(args);
+    return { found: false };
+  };
+
+  await streamChat({
+    message: "Was ist LF07?",
+    userId: 42,
+    sessionId: "session-42-ts",
+    chatRepository: makeChatRepository(),
+    courseRepository: makeCourseRepository(),
+    userRepository,
+    llmService: makeLlmService(),
+    searchCourses,
+    model: "test",
+    moodleBaseUrl: "https://moodle.example",
+    onChunk: async () => {},
+  });
+
+  assert.strictEqual(observed.length, 1);
+  assert.deepStrictEqual(observed[0].allowedIds, [5, 12]);
+});
+
+test("streamChat passes empty allowedIds when userProfile has no courses (searchCourses is fail-closed)", async () => {
+  const userRepository = makeUserRepository({ courses: [] });
+  const observed = [];
+  const searchCourses = async (args) => {
+    observed.push(args);
+    return { found: false };
+  };
+
+  await streamChat({
+    message: "anything",
+    userId: 7,
+    sessionId: "session-7-ts",
+    chatRepository: makeChatRepository(),
+    courseRepository: makeCourseRepository(),
+    userRepository,
+    llmService: makeLlmService(),
+    searchCourses,
+    model: "test",
+    moodleBaseUrl: "https://moodle.example",
+    onChunk: async () => {},
+  });
+
+  assert.deepStrictEqual(observed[0].allowedIds, []);
+});
+
+test("streamChat filters out non-positive-integer course ids before passing allowedIds", async () => {
+  const userRepository = makeUserRepository({
+    courses: [
+      { id: 5, name: "LF07", shortname: "LF07" },
+      { id: "abc", name: "Broken", shortname: "X" },
+      { id: 0, name: "Zero", shortname: "Z" },
+      { id: -3, name: "Negative", shortname: "N" },
+      { id: 1.5, name: "Float", shortname: "F" },
+      { id: null, name: "NullId", shortname: "K" },
+      { id: 9, name: "LF09", shortname: "LF09" },
+    ],
+  });
+  const observed = [];
+  const searchCourses = async (args) => {
+    observed.push(args);
+    return { found: false };
+  };
+
+  await streamChat({
+    message: "Was ist LF07?",
+    userId: 1,
+    sessionId: "session-1-ts",
+    chatRepository: makeChatRepository(),
+    courseRepository: makeCourseRepository(),
+    userRepository,
+    llmService: makeLlmService(),
+    searchCourses,
+    model: "test",
+    moodleBaseUrl: "https://moodle.example",
+    onChunk: async () => {},
+  });
+
+  assert.deepStrictEqual(observed[0].allowedIds, [5, 9]);
+});
+
+test("streamChat passes empty allowedIds when every course id is invalid", async () => {
+  const userRepository = makeUserRepository({
+    courses: [
+      { id: "x", name: "Bad", shortname: "B" },
+      { id: 0, name: "Zero", shortname: "Z" },
+    ],
+  });
+  const observed = [];
+  const searchCourses = async (args) => {
+    observed.push(args);
+    return { found: false };
+  };
+
+  await streamChat({
+    message: "x",
+    userId: 1,
+    sessionId: "session-1-ts",
+    chatRepository: makeChatRepository(),
+    courseRepository: makeCourseRepository(),
+    userRepository,
+    llmService: makeLlmService(),
+    searchCourses,
+    model: "test",
+    moodleBaseUrl: "https://moodle.example",
+    onChunk: async () => {},
+  });
+
+  assert.deepStrictEqual(observed[0].allowedIds, []);
+});
+
+test("streamChat passes empty allowedIds when userRepository throws (fallback profile has no courses)", async () => {
+  const userRepository = makeUserRepository({ fail: true });
+  const observed = [];
+  const searchCourses = async (args) => {
+    observed.push(args);
+    return { found: false };
+  };
+
+  await streamChat({
+    message: "anything",
+    userId: 99,
+    sessionId: "session-99-ts",
+    chatRepository: makeChatRepository(),
+    courseRepository: makeCourseRepository(),
+    userRepository,
+    llmService: makeLlmService(),
+    searchCourses,
+    model: "test",
+    moodleBaseUrl: "https://moodle.example",
+    onChunk: async () => {},
+  });
+
+  assert.deepStrictEqual(observed[0].allowedIds, []);
+});


### PR DESCRIPTION
- searchCourses is now fail-closed: omitting or emptying allowedIds short-circuits to {found:false} WITHOUT touching courseRepository, removing the previous fail-open path where the security invariant lived in the caller (streamChat) instead of the enforcer.
- streamChat builds allowedIds from userProfile.courses (filtered to positive integers only); no sentinel workaround.
- searchCourses.test.js: 12 existing tests updated to pass allowedIds, +2 new tests proving getAllCourses is never called when allowedIds is missing/empty (throw-mock asserts the call is not made).
- streamChat.test.js (new): 5 tests covering allowedIds derivation from userProfile.courses, including invalid-id filtering and the userRepository-throws fallback path.

Security invariant now lives at the enforcing boundary per nodejs-best-practices 'validate at the enforcing boundary' rule.

Tests: 352/352 pass. Lint: 0 errors.