### PR TITLE
deploy: separate prod integration stack and harden ops

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
         run: npm ci
 
       - name: Run npm audit
-        run: npm audit --omit=dev --audit-level=high
+        run: npm audit --omit=dev --audit-level=moderate
 
       - name: Run Gitleaks
         uses: gitleaks/gitleaks-action@v2
@@ -91,6 +91,17 @@ jobs:
       - name: Build proxy image
         run: docker build -f proxy/Dockerfile -t moodle-proxy:ci proxy
 
+      # Scan the built image for known OS/dependency vulnerabilities (DEP-08).
+      # ignore-unfixed avoids failing on CVEs with no available patch.
+      - name: Scan proxy image (Trivy)
+        uses: aquasecurity/trivy-action@0.24.0
+        with:
+          image-ref: moodle-proxy:ci
+          format: table
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          exit-code: "1"
+
       # Smoke test: the container must START and serve /health. Moodle/Ollama are
       # unreachable in CI, so a degraded 503 counts as success — what we catch
       # here is crash-on-start (e.g. a missing required env var like
@@ -104,6 +115,7 @@ jobs:
             -e OLLAMA_URL=http://ollama.invalid \
             -e OLLAMA_MODEL=llama3.2:3b \
             -e CHATBOT_AUTH_SECRET=ci-dummy-secret \
+            -e CHAT_ENCRYPTION_KEY=0000000000000000000000000000000000000000000000000000000000000000 \
             -e PUBLIC_MOODLE_URL=https://example.test \
             -e CORS_ORIGIN=https://example.test \
             -e CHAT_DB_PATH=/tmp/chat.db \

--- a/backup-moodle.sh
+++ b/backup-moodle.sh
@@ -9,10 +9,15 @@ set -o pipefail
 # Cron example (runs at 03:00 daily):
 #   0 3 * * * MYSQL_ROOT_PASSWORD=secret /home/admin/moodle/backup-moodle.sh
 
-BACKUP_DIR="/home/admin/moodle/backups"
+# Paths derive from the script's own location so the backup works on any host
+# (no hardcoded /home/admin). Overridable via env for custom layouts.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BACKUP_DIR="${BACKUP_DIR:-$SCRIPT_DIR/backups}"
 TIMESTAMP=$(date +%Y%m%d_%H%M%S)
-COMPOSE_DIR="/home/admin/moodle/compose"
-LOG_FILE="/home/admin/moodle/backup.log"
+COMPOSE_DIR="${COMPOSE_DIR:-$SCRIPT_DIR/compose}"
+LOG_FILE="${LOG_FILE:-$SCRIPT_DIR/backup.log}"
+DATA_DIR="${DATA_DIR:-$SCRIPT_DIR/data}"
+MARIADB_CONTAINER="${MARIADB_CONTAINER:-moodle-stack-mariadb-1}"
 
 mkdir -p "$BACKUP_DIR"
 chmod 700 "$BACKUP_DIR"
@@ -37,7 +42,7 @@ fi
 
 # 1. Create database dump
 log "Creating database dump..."
-docker exec moodle-stack-mariadb-1 mysqldump \
+docker exec $MARIADB_CONTAINER mysqldump \
   -u root \
   --password="$MYSQL_ROOT_PASSWORD" \
   --single-transaction \
@@ -54,8 +59,8 @@ fi
 
 # 2. Backup chat database (SQLite) using the built-in hot backup API
 log "Backing up chat database..."
-if [ -f "/home/admin/moodle/data/chat.db" ]; then
-    sqlite3 "/home/admin/moodle/data/chat.db" \
+if [ -f "$DATA_DIR/chat.db" ]; then
+    sqlite3 "$DATA_DIR/chat.db" \
       ".backup '$BACKUP_DIR/chat_db_$TIMESTAMP.db'"
     if [ $? -eq 0 ]; then
         log "✓ Chat database backed up: chat_db_$TIMESTAMP.db"
@@ -68,9 +73,9 @@ fi
 
 # 3. Archive user files (moodledata)
 log "Archiving user files..."
-if [ -d "/home/admin/moodle/data/moodledata" ]; then
+if [ -d "$DATA_DIR/moodledata" ]; then
     tar -czf "$BACKUP_DIR/moodledata_$TIMESTAMP.tar.gz" \
-      -C /home/admin/moodle/data \
+      -C $DATA_DIR \
       --warning=no-file-changed \
       moodledata 2>/dev/null
 
@@ -87,12 +92,12 @@ fi
 # 4. Archive custom themes and plugins (if any)
 log "Archiving custom Moodle files..."
 CUSTOM_DIRS=()
-[ -d "/home/admin/moodle/data/moodle/theme" ] && CUSTOM_DIRS+=("theme/")
-[ -d "/home/admin/moodle/data/moodle/local" ] && CUSTOM_DIRS+=("local/")
+[ -d "$DATA_DIR/moodle/theme" ] && CUSTOM_DIRS+=("theme/")
+[ -d "$DATA_DIR/moodle/local" ] && CUSTOM_DIRS+=("local/")
 
 if [ ${#CUSTOM_DIRS[@]} -gt 0 ]; then
     tar -czf "$BACKUP_DIR/moodle_custom_$TIMESTAMP.tar.gz" \
-      -C /home/admin/moodle/data/moodle \
+      -C $DATA_DIR/moodle \
       --exclude='cache/*' \
       --exclude='localcache/*' \
       --warning=no-file-changed \

--- a/compose/docker-compose.prod.yml
+++ b/compose/docker-compose.prod.yml
@@ -1,61 +1,30 @@
-# SELF-CONTAINED DEMO STACK — bundles its OWN Moodle + MariaDB.
+# Production stack — INTEGRATION beside an EXISTING school Moodle.
 #
-# Use this file for demos / local evaluation, where there is no pre-existing
-# Moodle. nginx fronts the bundled Moodle at "/" and the chatbot at /api,
-# /chatbot, /health on the same domain.
+# Use this file when the school already runs its own Moodle 4.4 + MariaDB.
+# It does NOT start Moodle or MariaDB: the proxy talks to the existing Moodle
+# over its REST API (MOODLE_URL), and nginx serves ONLY the chatbot on a
+# dedicated subdomain (e.g. chat.school.de) — it never proxies "/" to Moodle.
 #
-# For deployment BESIDE an existing school Moodle, use docker-compose.prod.yml
-# instead — it omits Moodle/MariaDB and points the proxy at the real Moodle.
-# Do NOT run both against the same domain.
+#   docker compose -f docker-compose.prod.yml --env-file ../.env up -d
 #
-# Docker image versions pinned 2026-06-01
-# Reason: reproducible builds, avoid breaking changes from unpinned latest tags
-# See DECISIONS.md "Pin Docker images" for upgrade policy
-# SSL: run compose/setup-ssl.sh once before first `docker compose up`
-name: moodle-stack
+# The self-contained demo stack (bundled Moodle + MariaDB) lives in
+# docker-compose.yml. Do NOT run both against the same domain.
+#
+# Image versions pinned 2026-06-01 — see DECISIONS.md "Pin Docker images".
+# SSL: run compose/setup-ssl.sh once before first `up` (uses NGINX_DOMAIN).
+name: moodle-chatbot
+
 services:
-  mariadb:
-    image: bitnamilegacy/mariadb:11.8.2-debian-12-r5
-    restart: unless-stopped
-    environment:
-      - ALLOW_EMPTY_PASSWORD=no
-      - MARIADB_USER=${MARIADB_USER}
-      - MARIADB_PASSWORD=${MARIADB_PASSWORD}
-      - MARIADB_ROOT_PASSWORD=${MARIADB_ROOT_PASSWORD}
-      - MARIADB_DATABASE=${MARIADB_DATABASE}
-      - MARIADB_CHARACTER_SET=utf8mb4
-      - MARIADB_COLLATE=utf8mb4_unicode_ci
-    volumes:
-      - ../data/mariadb:/bitnami/mariadb
-    networks: [moodle_net]
-    # Resource limits (DEP-02): cap every service so an Ollama memory spike
-    # cannot OOM the host and take down the database / Moodle.
-    mem_limit: 1g
-    cpus: "1.0"
-
-  moodle:
-    build:
-      context: .
-      dockerfile: Dockerfile.moodle
-    restart: unless-stopped
-    depends_on: [mariadb]
-    ports:
-      - "127.0.0.1:${MOODLE_HTTP_PORT}:8080"
-    volumes:
-      - ../data/moodle:/bitnami/moodle
-      - ../data/moodledata:/bitnami/moodledata
-    networks: [moodle_net]
-    mem_limit: 1g
-    cpus: "2.0"
-
   ollama:
     image: ollama/ollama:0.12.0
     restart: unless-stopped
     volumes:
       - ../data/ollama:/root/.ollama
-    networks: [moodle_net]
-    # Memory-hungry service — size mem_limit to the chosen model. llama3.2:3b
-    # fits in ~6g; raise for larger models or the host OOM killer may strike.
+    networks: [chatbot_net]
+    # Resource limits (DEP-02): Ollama is the memory-hungry service. Size
+    # mem_limit to the chosen model so a generation spike cannot OOM the host
+    # and disturb co-located services. llama3.2:3b fits in ~6g; raise for
+    # larger models.
     mem_limit: 8g
     mem_reservation: 4g
     cpus: "4.0"
@@ -80,7 +49,7 @@ services:
       - 'until ollama list >/dev/null 2>&1; do echo "waiting for ollama..."; sleep 2; done; ollama pull ${OLLAMA_MODEL} || { echo "ERROR: failed to pull ${OLLAMA_MODEL}"; exit 1; }; ollama list | grep -qF "${OLLAMA_MODEL}" || { echo "ERROR: ${OLLAMA_MODEL} not present after pull"; exit 1; }; echo "model ${OLLAMA_MODEL} ready"'
     environment:
       - OLLAMA_HOST=ollama:11434
-    networks: [moodle_net]
+    networks: [chatbot_net]
     mem_limit: 512m
     cpus: "1.0"
     restart: "no"
@@ -92,7 +61,9 @@ services:
     restart: unless-stopped
     environment:
       - NODE_ENV=production
-      - MOODLE_URL=http://moodle:8080
+      # MOODLE_URL points at the EXISTING school Moodle (REST base origin),
+      # e.g. https://www.itech-bs14.de — NOT a bundled container.
+      - MOODLE_URL=${MOODLE_URL}
       - MOODLE_TOKEN=${MOODLE_TOKEN}
       - OLLAMA_URL=${OLLAMA_URL}
       - OLLAMA_MODEL=${OLLAMA_MODEL}
@@ -124,12 +95,14 @@ services:
       - CACHE_TTL_USERS=${CACHE_TTL_USERS:-60000}
     volumes:
       - ../data:/data
-    networks: [moodle_net]
+    networks: [chatbot_net]
+    # Only depends on Ollama, and on START not HEALTH (DEP-07): the proxy must
+    # boot and serve /health (degraded) + static assets even if Ollama is down,
+    # rather than being held back by the LLM. No dependency on Moodle — it is
+    # external and reached over the network at request time.
     depends_on:
-      moodle:
-        condition: service_started
       ollama:
-        condition: service_healthy
+        condition: service_started
     mem_limit: 512m
     mem_reservation: 256m
     cpus: "1.0"
@@ -140,12 +113,12 @@ services:
       retries: 3
 
   # nginx 1.27.4 pinned 2026-05-29
+  # Serves the chatbot on a dedicated subdomain (NGINX_DOMAIN, e.g.
+  # chat.school.de). It exposes ONLY /api, /chatbot, /health — it does not
+  # touch the school's Moodle domain, so there is no port/route collision.
   nginx:
     image: nginx:1.27.4
     restart: unless-stopped
-    # envsubst replaces ${NGINX_DOMAIN} in the template; $host etc. are nginx vars, not shell vars.
-    # $$NGINX_DOMAIN: $$ is a Compose escape for a literal $, so the container receives '$NGINX_DOMAIN'
-    # as the variable-names argument to envsubst (not the resolved value).
     entrypoint: ["/bin/sh", "-c", "envsubst '$$NGINX_DOMAIN' < /tmp/nginx.conf.template > /etc/nginx/nginx.conf && exec nginx -g 'daemon off;'"]
     environment:
       - NGINX_DOMAIN=${NGINX_DOMAIN}
@@ -153,14 +126,14 @@ services:
       - "80:80"
       - "443:443"
     volumes:
-      - ./nginx/nginx.conf.template:/tmp/nginx.conf.template:ro
+      - ./nginx/nginx.prod.conf.template:/tmp/nginx.conf.template:ro
       - ../data/certbot:/etc/letsencrypt:ro
       - ../data/certbot-webroot:/var/www/certbot:ro
-    networks: [moodle_net]
+    networks: [chatbot_net]
     mem_limit: 128m
     cpus: "0.5"
-    depends_on: [proxy, moodle]
+    depends_on: [proxy]
 
 networks:
-  moodle_net:
+  chatbot_net:
     driver: bridge

--- a/compose/nginx/nginx.prod.conf.template
+++ b/compose/nginx/nginx.prod.conf.template
@@ -1,0 +1,79 @@
+# Reverse proxy for the Moodle AI Chatbot — PRODUCTION (integration mode).
+#
+# This vhost serves ONLY the chatbot on its own subdomain (NGINX_DOMAIN, e.g.
+# chat.school.de). Unlike the demo template, it has NO `location / -> moodle`
+# block: the school's existing Moodle keeps its own domain and web server, and
+# this proxy never intercepts its traffic.
+#
+# NGINX_DOMAIN is injected at startup via envsubst. It must be the chatbot
+# subdomain, and must be included in the chatbot's CORS_ORIGIN / the Moodle
+# page CSP connect-src so the embedded widget can reach /api.
+# SSL certificates: managed by certbot (see compose/setup-ssl.sh).
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    # HTTP: serve ACME challenge for certbot renewal, redirect everything else to HTTPS
+    server {
+        listen 80;
+        server_name ${NGINX_DOMAIN};
+
+        location /.well-known/acme-challenge/ {
+            root /var/www/certbot;
+        }
+
+        location / {
+            return 301 https://$host$request_uri;
+        }
+    }
+
+    # HTTPS — chatbot subdomain only
+    server {
+        listen 443 ssl;
+        server_name ${NGINX_DOMAIN};
+
+        ssl_certificate     /etc/letsencrypt/live/${NGINX_DOMAIN}/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/${NGINX_DOMAIN}/privkey.pem;
+        ssl_protocols       TLSv1.2 TLSv1.3;
+        ssl_prefer_server_ciphers on;
+
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+
+        # Chat API — SSE streaming: buffering must be off or chunks arrive only at stream end.
+        # proxy_read_timeout covers long LLM responses (default 60s is too short).
+        location /api/ {
+            proxy_pass         http://proxy:3000;
+            proxy_buffering    off;
+            proxy_cache        off;
+            proxy_read_timeout 300s;
+            proxy_http_version 1.1;
+            proxy_set_header   Connection "";
+            proxy_set_header   Host $host;
+            proxy_set_header   X-Real-IP $remote_addr;
+            proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header   X-Forwarded-Proto $scheme;
+        }
+
+        # Chatbot static assets — served by Node.js proxy
+        location /chatbot/ {
+            proxy_pass       http://proxy:3000;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        location /health {
+            proxy_pass       http://proxy:3000;
+            proxy_set_header Host $host;
+        }
+
+        # No `location /` — this server does not front the school's Moodle.
+        # Any other path returns 404 from nginx.
+        location / {
+            return 404;
+        }
+    }
+}

--- a/compose/restore-moodle.sh
+++ b/compose/restore-moodle.sh
@@ -29,18 +29,34 @@ if [[ ! -f "$ARCHIVE" ]]; then
   exit 1
 fi
 
-# --- Safety check: warn if any stack container is running ---------------------
+# --- Safety check: refuse to restore while the stack is running ---------------
+# Query by explicit project name (set via `name:` in docker-compose.yml) so the
+# check is reliable regardless of the working directory or --env-file used at
+# deploy time. Fail CLOSED: if container status cannot be determined, treat it
+# as "possibly running" and require explicit confirmation — never silently
+# overwrite live data dirs under a running MariaDB.
+PROJECT_NAME="moodle-stack"
 
-if docker compose -f "$SCRIPT_DIR/docker-compose.yml" ps --services --filter status=running 2>/dev/null | grep -q .; then
-  echo "WARNING: one or more stack containers are still running."
-  echo "Stop the stack first:"
-  echo "  cd compose && docker compose down"
-  echo ""
-  read -rp "Continue anyway? [y/N] " CONFIRM
+if RUNNING="$(docker compose -p "$PROJECT_NAME" ps --services --filter status=running 2>/dev/null)"; then
+  STATUS_KNOWN=1
+else
+  STATUS_KNOWN=0
+fi
+
+if [[ "$STATUS_KNOWN" -eq 0 ]]; then
+  echo "WARNING: could not determine whether the '$PROJECT_NAME' stack is running."
+  echo "Restoring over a live data directory will corrupt it."
+  read -rp "Are you certain the stack is stopped? Continue anyway? [y/N] " CONFIRM
   if [[ "${CONFIRM,,}" != "y" ]]; then
     echo "Aborted."
     exit 1
   fi
+elif [[ -n "$RUNNING" ]]; then
+  echo "ERROR: one or more '$PROJECT_NAME' containers are still running:"
+  echo "$RUNNING" | sed 's/^/  - /'
+  echo "Stop the stack first:"
+  echo "  cd compose && docker compose down"
+  exit 1
 fi
 
 # --- Restore ------------------------------------------------------------------

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -18,6 +18,29 @@ Dieses Dokument beschreibt die Erstinstallation sowie alle wiederkehrenden Betri
 
 ---
 
+## Deployment-Modelle: welche Compose-Datei?
+
+Es gibt zwei Betriebsmodelle. Niemals beide gegen dieselbe Domain betreiben.
+
+| Modell | Datei | Wann verwenden |
+|--------|-------|----------------|
+| **Demo / lokal (self-contained)** | `compose/docker-compose.yml` | Demonstration oder Evaluierung ohne vorhandenes Moodle. Startet eigenes Moodle + MariaDB + Ollama + Proxy; nginx liefert Moodle unter `/`. |
+| **Produktion / Integration** | `compose/docker-compose.prod.yml` | Neben einem bereits existierenden Schul-Moodle. Startet **kein** Moodle/MariaDB. Der Proxy spricht das vorhandene Moodle über `MOODLE_URL` an; nginx bedient nur `/api`, `/chatbot`, `/health` auf einer eigenen Subdomain (`NGINX_DOMAIN`, z. B. `chat.schule.de`). |
+
+**Produktion starten:**
+
+```bash
+cd compose
+# NGINX_DOMAIN = Chatbot-Subdomain; MOODLE_URL = existierendes Moodle (REST-Origin)
+docker compose -f docker-compose.prod.yml --env-file ../.env up -d
+```
+
+Wichtig für die Integration: `CORS_ORIGIN` muss die Moodle-Origin enthalten (dort
+wird das Widget eingebettet), und die Moodle-Seiten-CSP (`script-src`, `connect-src`)
+muss die Chatbot-Subdomain erlauben.
+
+---
+
 ## Voraussetzungen
 
 | Komponente | Version | Hinweis |


### PR DESCRIPTION
Add a production deployment mode that integrates beside an existing school Moodle instead of bundling its own, plus deployment/CI hardening from the readiness review.

- DEP-01: new docker-compose.prod.yml (proxy + ollama + nginx, no Moodle/ MariaDB) and nginx.prod.conf.template (chatbot subdomain only, no `location / -> moodle`); mark docker-compose.yml as the self-contained demo stack; document both modes in docs/setup.md
- DEP-02: memory/CPU limits on every service in both compose files
- DEP-06: ollama-init fails loudly if the model is not present after pull
- DEP-04: restore-moodle.sh checks by explicit project name and fails closed
- DEP-09: backup-moodle.sh derives paths from its location (no hardcoded /home/admin), MariaDB container name overridable
- DEP-08: CI scans the built image with Trivy and raises npm audit to moderate; smoke test passes CHAT_ENCRYPTION_KEY (now required in production)