### PR TITLE
security: harden access control, auth tokens and error responses

### DIFF
--- a/proxy/src/frameworks/webserver/routes/index.js
+++ b/proxy/src/frameworks/webserver/routes/index.js
@@ -1,3 +1,14 @@
+// Internal-only guard: diagnostic and admin endpoints expose PII or operational
+// internals and must never be reachable from outside the host. Gating on the
+// loopback address is independent of NODE_ENV, so a misconfigured environment
+// cannot accidentally expose them. Returns the reply to halt the chain on deny.
+async function requireLoopback(request, reply) {
+  const ip = request.ip;
+  if (ip !== "127.0.0.1" && ip !== "::1" && ip !== "::ffff:127.0.0.1") {
+    return reply.code(403).send({ error: "Forbidden" });
+  }
+}
+
 /**
  * Registers all HTTP routes on the Fastify instance.
  *
@@ -56,14 +67,7 @@ export async function registerRoutes(app, controllers, options = {}) {
   if (typeof health.checkDetails === "function") {
     app.get(
       "/health/details",
-      {
-        preHandler: async (request, reply) => {
-          const ip = request.ip;
-          if (ip !== "127.0.0.1" && ip !== "::1" && ip !== "::ffff:127.0.0.1") {
-            return reply.code(403).send({ error: "Forbidden" });
-          }
-        },
-      },
+      { preHandler: requireLoopback },
       health.checkDetails.bind(health),
     );
   }
@@ -135,7 +139,11 @@ export async function registerRoutes(app, controllers, options = {}) {
     history.delete.bind(history),
   );
 
-  // Moodle endpoints
+  // Moodle endpoints.
+  // `/moodle/ping` is a PII-free liveness probe and stays public. The remaining
+  // routes are diagnostic-only (they expose user PII and cache internals, with
+  // no consumer in the chat flow), so they are restricted to loopback in
+  // addition to the production block enforced in the controller.
   app.get("/moodle/ping", moodle.ping.bind(moodle));
 
   const userIdParamSchema = {
@@ -149,7 +157,7 @@ export async function registerRoutes(app, controllers, options = {}) {
   };
   app.get(
     "/moodle/users/:userId/courses",
-    { schema: userIdParamSchema },
+    { schema: userIdParamSchema, preHandler: requireLoopback },
     moodle.getUserCourses.bind(moodle),
   );
 
@@ -162,21 +170,22 @@ export async function registerRoutes(app, controllers, options = {}) {
       },
     },
   };
-  app.get("/moodle/user/:id", { schema: idParamSchema }, moodle.getUser.bind(moodle));
-  app.get("/moodle/debug/cache", moodle.debugCache.bind(moodle));
+  app.get(
+    "/moodle/user/:id",
+    { schema: idParamSchema, preHandler: requireLoopback },
+    moodle.getUser.bind(moodle),
+  );
+  app.get(
+    "/moodle/debug/cache",
+    { preHandler: requireLoopback },
+    moodle.debugCache.bind(moodle),
+  );
 
   // Cache invalidation — localhost only
   if (invalidateCourseCache) {
     app.post(
       "/admin/cache/invalidate",
-      {
-        preHandler: async (request, reply) => {
-          const ip = request.ip;
-          if (ip !== "127.0.0.1" && ip !== "::1" && ip !== "::ffff:127.0.0.1") {
-            reply.code(403).send({ error: "Forbidden" });
-          }
-        },
-      },
+      { preHandler: requireLoopback },
       async (_request, reply) => {
         invalidateCourseCache();
         return reply.code(200).send({ ok: true });

--- a/proxy/src/middleware/auth.js
+++ b/proxy/src/middleware/auth.js
@@ -19,6 +19,11 @@ function denyOwnership(request, reply, userId) {
   return reply.status(403).send({ statusCode: 403, error: "Forbidden" });
 }
 
+// Tolerance for a token timestamp in the future, covering minor client/server
+// clock skew. Beyond this, a future-dated `ts` is rejected so it cannot widen
+// the replay window past `tokenTtlMs` (AUTH-TTL).
+const CLOCK_SKEW_MS = 60_000;
+
 /**
  * Factory for a Fastify preHandler that verifies the caller's Moodle identity.
  *
@@ -31,11 +36,22 @@ function denyOwnership(request, reply, userId) {
  *
  * @param {Object} deps
  * @param {string} deps.secret  Shared HMAC secret, also configured in Moodle.
+ * @param {string[]} [deps.previousSecrets=[]]  Additional secrets still accepted
+ *   during a rotation overlap window. Lets the proxy validate tokens signed with
+ *   either the new or the old secret so a key can be rotated with zero downtime
+ *   (AUTH-KID): deploy proxy accepting [new, old] → switch Moodle to new → drop old.
  * @param {number} [deps.tokenTtlMs=7_200_000]  Max age of a signed token in ms.
  * @param {function(): number} [deps.now=Date.now]
  * @returns {function(import("fastify").FastifyRequest, import("fastify").FastifyReply): Promise<void>}
  */
-export function createVerifyMoodleUser({ secret, tokenTtlMs = 7_200_000, now = Date.now }) {
+export function createVerifyMoodleUser({
+  secret,
+  previousSecrets = [],
+  tokenTtlMs = 7_200_000,
+  now = Date.now,
+}) {
+  const acceptedSecrets = [secret, ...previousSecrets].filter(Boolean);
+
   function parseUserId(value) {
     const num = Number(value);
     return Number.isInteger(num) && num > 0 ? num : 0;
@@ -49,30 +65,51 @@ export function createVerifyMoodleUser({ secret, tokenTtlMs = 7_200_000, now = D
     return reply.status(401).send({ statusCode: 401, error: "Unauthorized" });
   }
 
+  // Constant-time match against every accepted secret (no early return on the
+  // first miss, so verification time does not reveal which secret matched).
+  function signatureMatchesAnySecret(userId, ts, sig) {
+    let matched = false;
+    for (const candidate of acceptedSecrets) {
+      const expected = createHmac("sha256", candidate).update(`${userId}.${ts}`).digest("hex");
+      if (expected.length === sig.length && timingSafeEqual(Buffer.from(expected), Buffer.from(sig))) {
+        matched = true;
+      }
+    }
+    return matched;
+  }
+
   return async function verifyMoodleUser(request, reply) {
-    // Identity may arrive in the JSON body (POST) or the query string
-    // (GET/DELETE chat-history). Body wins when both are present.
-    const src = { ...(request.query ?? {}), ...(request.body ?? {}) };
+    // Identity may arrive in the JSON body (POST chat-stream) or, for
+    // GET/DELETE chat-history, in `X-Chat-*` request headers. The query string
+    // is still accepted (lowest precedence) for backward compatibility, but the
+    // client now sends headers to keep identity out of URLs/logs (F-08).
+    const headers = request.headers ?? {};
+    const fromHeaders = {
+      userId: headers["x-chat-user"],
+      ts: headers["x-chat-ts"],
+      sig: headers["x-chat-sig"],
+    };
+    const src = {
+      ...(request.query ?? {}),
+      ...Object.fromEntries(Object.entries(fromHeaders).filter(([, v]) => v !== undefined)),
+      ...(request.body ?? {}),
+    };
     const userId = parseUserId(src.userId);
     const ts = Number(src.ts);
     const sig = typeof src.sig === "string" ? src.sig : "";
 
-    if (!secret || userId === 0 || !Number.isFinite(ts) || sig === "") {
+    if (acceptedSecrets.length === 0 || userId === 0 || !Number.isFinite(ts) || sig === "") {
       return deny(request, reply, userId);
     }
 
-    // Reject stale tokens; abs() also tolerates minor client/server clock skew.
-    if (Math.abs(now() - ts) > tokenTtlMs) {
+    // Reject stale tokens (older than the TTL) and future-dated tokens beyond a
+    // small clock-skew tolerance.
+    const age = now() - ts;
+    if (age > tokenTtlMs || age < -CLOCK_SKEW_MS) {
       return deny(request, reply, userId);
     }
 
-    const expected = createHmac("sha256", secret).update(`${userId}.${ts}`).digest("hex");
-
-    // Constant-time comparison; length guard avoids timingSafeEqual throwing.
-    const valid =
-      expected.length === sig.length && timingSafeEqual(Buffer.from(expected), Buffer.from(sig));
-
-    if (!valid) {
+    if (!signatureMatchesAnySecret(userId, ts, sig)) {
       return deny(request, reply, userId);
     }
 

--- a/proxy/src/middleware/errorHandler.js
+++ b/proxy/src/middleware/errorHandler.js
@@ -12,10 +12,15 @@ export function setupErrorHandler(server) {
       statusCode,
     });
 
+    // In production only expose messages that are explicitly client-safe:
+    // Fastify schema-validation errors (statusCode < 500 with `validation`) and
+    // errors deliberately flagged `expose: true`. Everything else — including
+    // arbitrary 4xx thrown deeper in the stack — gets a generic message so no
+    // internal detail (paths, identifiers, library internals) leaks.
+    const clientSafe =
+      statusCode < 500 && (error.expose === true || Array.isArray(error.validation));
     const message =
-      config.nodeEnv === "production" && statusCode >= 500
-        ? "Ein Fehler ist aufgetreten."
-        : error.message;
+      config.nodeEnv !== "production" || clientSafe ? error.message : "Ein Fehler ist aufgetreten.";
 
     reply.status(statusCode).send({ error: true, message });
   });

--- a/proxy/tests/integration/routes.test.js
+++ b/proxy/tests/integration/routes.test.js
@@ -176,3 +176,36 @@ test("GET /moodle/user/:id with invalid id returns 400", async () => {
   assert.strictEqual(response.statusCode, 400);
   await app.close();
 });
+
+test("GET /moodle/user/:id from a non-loopback IP returns 403", async () => {
+  const app = await buildApp();
+  const response = await app.inject({
+    method: "GET",
+    url: "/moodle/user/7",
+    remoteAddress: "203.0.113.10",
+  });
+  assert.strictEqual(response.statusCode, 403);
+  await app.close();
+});
+
+test("GET /moodle/users/:userId/courses from a non-loopback IP returns 403", async () => {
+  const app = await buildApp();
+  const response = await app.inject({
+    method: "GET",
+    url: "/moodle/users/42/courses",
+    remoteAddress: "203.0.113.10",
+  });
+  assert.strictEqual(response.statusCode, 403);
+  await app.close();
+});
+
+test("GET /moodle/debug/cache from a non-loopback IP returns 403", async () => {
+  const app = await buildApp();
+  const response = await app.inject({
+    method: "GET",
+    url: "/moodle/debug/cache",
+    remoteAddress: "203.0.113.10",
+  });
+  assert.strictEqual(response.statusCode, 403);
+  await app.close();
+});

--- a/proxy/tests/unit/middleware/auth.test.js
+++ b/proxy/tests/unit/middleware/auth.test.js
@@ -174,6 +174,83 @@ test("returns 401 when no secret is configured", async () => {
   assert.strictEqual(reply._calls[0].code, 401);
 });
 
+test("accepts identity supplied via X-Chat-* request headers (F-08)", async () => {
+  const verify = createVerifyMoodleUser({ secret: SECRET, now: () => 1000 });
+  const ts = 1000;
+  const request = {
+    body: {},
+    query: {},
+    headers: { "x-chat-user": "42", "x-chat-ts": String(ts), "x-chat-sig": sign(42, ts) },
+    log: { warn() {} },
+    ip: "127.0.0.1",
+  };
+  const reply = createMockReply();
+
+  await verify(request, reply);
+
+  assert.strictEqual(reply._calls.length, 0);
+  assert.strictEqual(request.verifiedUserId, 42);
+});
+
+test("returns 401 for a future-dated token beyond the clock-skew tolerance (AUTH-TTL)", async () => {
+  const ts = 1_000_000; // far in the future relative to now()
+  const verify = createVerifyMoodleUser({ secret: SECRET, tokenTtlMs: 5000, now: () => 1000 });
+  const request = createMockRequest({ body: { userId: 42, ts, sig: sign(42, ts) } });
+  const reply = createMockReply();
+
+  await verify(request, reply);
+
+  assert.strictEqual(reply._calls[0].code, 401);
+  assert.strictEqual(request.verifiedUserId, undefined);
+});
+
+test("accepts a slightly future-dated token within the clock-skew tolerance", async () => {
+  const ts = 1500; // 500ms ahead of now(); within the 60s skew window
+  const verify = createVerifyMoodleUser({ secret: SECRET, tokenTtlMs: 5000, now: () => 1000 });
+  const request = createMockRequest({ body: { userId: 42, ts, sig: sign(42, ts) } });
+  const reply = createMockReply();
+
+  await verify(request, reply);
+
+  assert.strictEqual(reply._calls.length, 0);
+  assert.strictEqual(request.verifiedUserId, 42);
+});
+
+test("accepts a token signed with a previous secret during rotation (AUTH-KID)", async () => {
+  const OLD = "old-secret";
+  const verify = createVerifyMoodleUser({
+    secret: "new-secret",
+    previousSecrets: [OLD],
+    now: () => 1000,
+  });
+  const ts = 1000;
+  const request = createMockRequest({ body: { userId: 42, ts, sig: sign(42, ts, OLD) } });
+  const reply = createMockReply();
+
+  await verify(request, reply);
+
+  assert.strictEqual(reply._calls.length, 0);
+  assert.strictEqual(request.verifiedUserId, 42);
+});
+
+test("rejects a token signed with a secret that is neither current nor previous", async () => {
+  const verify = createVerifyMoodleUser({
+    secret: "new-secret",
+    previousSecrets: ["old-secret"],
+    now: () => 1000,
+  });
+  const ts = 1000;
+  const request = createMockRequest({
+    body: { userId: 42, ts, sig: sign(42, ts, "unrelated-secret") },
+  });
+  const reply = createMockReply();
+
+  await verify(request, reply);
+
+  assert.strictEqual(reply._calls[0].code, 401);
+  assert.strictEqual(request.verifiedUserId, undefined);
+});
+
 test("logs security warning on failure without leaking details", async () => {
   const warnings = [];
   const verify = createVerifyMoodleUser({ secret: SECRET, now: () => 1000 });

--- a/proxy/tests/unit/middleware/errorHandler.test.js
+++ b/proxy/tests/unit/middleware/errorHandler.test.js
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import { test, beforeEach, afterEach } from "vitest";
+
+async function importErrorHandler() {
+  process.env.MOODLE_URL = "https://moodle.example.test";
+  process.env.MOODLE_TOKEN = "test-token";
+  process.env.OLLAMA_URL = "http://ollama.example.test";
+  process.env.OLLAMA_MODEL = "llama-default";
+
+  const handlerUrl = new URL("../../../src/middleware/errorHandler.js", import.meta.url);
+  handlerUrl.searchParams.set("cacheBust", crypto.randomUUID());
+  const { setupErrorHandler } = await import(handlerUrl.href);
+  const { default: config } = await import("../../../src/config/env.js");
+  return { setupErrorHandler, config };
+}
+
+// Captures the handler registered via setErrorHandler and a fake reply.
+function run(setupErrorHandler, error) {
+  let handler;
+  setupErrorHandler({ setErrorHandler: (fn) => (handler = fn) });
+
+  const reply = {
+    _status: null,
+    _sent: null,
+    status(code) {
+      this._status = code;
+      return this;
+    },
+    send(data) {
+      this._sent = data;
+    },
+  };
+  const request = { id: "req-1", url: "/x", method: "POST", log: { error() {} } };
+  handler(error, request, reply);
+  return reply;
+}
+
+let savedNodeEnv;
+beforeEach(() => {
+  savedNodeEnv = process.env.NODE_ENV;
+});
+afterEach(() => {
+  process.env.NODE_ENV = savedNodeEnv;
+});
+
+test("production masks a 5xx error message", async () => {
+  const { setupErrorHandler, config } = await importErrorHandler();
+  config.nodeEnv = "production";
+  const reply = run(setupErrorHandler, Object.assign(new Error("db dsn leaked"), { statusCode: 500 }));
+  assert.strictEqual(reply._status, 500);
+  assert.strictEqual(reply._sent.message, "Ein Fehler ist aufgetreten.");
+});
+
+test("production masks an arbitrary 4xx error message (no expose flag)", async () => {
+  const { setupErrorHandler, config } = await importErrorHandler();
+  config.nodeEnv = "production";
+  const reply = run(setupErrorHandler, Object.assign(new Error("internal path /etc/x"), { statusCode: 403 }));
+  assert.strictEqual(reply._status, 403);
+  assert.strictEqual(reply._sent.message, "Ein Fehler ist aufgetreten.");
+});
+
+test("production exposes a schema-validation 4xx message", async () => {
+  const { setupErrorHandler, config } = await importErrorHandler();
+  config.nodeEnv = "production";
+  const err = Object.assign(new Error("body/message must be string"), {
+    statusCode: 400,
+    validation: [{ message: "must be string" }],
+  });
+  const reply = run(setupErrorHandler, err);
+  assert.strictEqual(reply._status, 400);
+  assert.strictEqual(reply._sent.message, "body/message must be string");
+});
+
+test("production exposes an error explicitly flagged expose:true", async () => {
+  const { setupErrorHandler, config } = await importErrorHandler();
+  config.nodeEnv = "production";
+  const err = Object.assign(new Error("safe to show"), { statusCode: 400, expose: true });
+  const reply = run(setupErrorHandler, err);
+  assert.strictEqual(reply._sent.message, "safe to show");
+});
+
+test("development exposes the raw message", async () => {
+  const { setupErrorHandler, config } = await importErrorHandler();
+  config.nodeEnv = "development";
+  const reply = run(setupErrorHandler, Object.assign(new Error("verbose dev detail"), { statusCode: 500 }));
+  assert.strictEqual(reply._sent.message, "verbose dev detail");
+});


### PR DESCRIPTION
- MOO-02/PR-08: restrict the diagnostic /moodle/* endpoints (user PII, cache stats) and /admin/cache/invalidate to loopback via a shared requireLoopback guard, independent of NODE_ENV; fixes the missing `return` that let the admin side effect run after a 403
- AUTH-TTL: reject future-dated tokens beyond a 60s clock-skew tolerance so a token cannot widen the replay window past its TTL
- AUTH-KID: accept a set of secrets ([secret, ...previousSecrets]) with a constant-time match, enabling zero-downtime HMAC key rotation
- F-08 (server side): read signed identity from X-Chat-* headers (body >
  headers > query) so GET/DELETE no longer require it in the URL
- PR-02: in production only expose error messages for schema-validation or explicitly safe errors; generic message for all other 4xx and every 5xx

Adds integration tests for the loopback guard and unit tests for future-ts rejection, key rotation, header identity, and the error-handler masking.