### PR TITLE
fix(landing): professional responsive design across all devices

### DIFF
--- a/landing/src/App.css
+++ b/landing/src/App.css
@@ -6,12 +6,13 @@
 
 /* ---------- Shared section heads ---------- */
 .section__title {
-  font-size: 1.75rem;          /* 28px — matches h2 */
+  font-size: clamp(1.4rem, 4.5vw, 1.75rem);   /* fluid 22.4 → 28px */
   font-weight: 700;
   margin-top: 0.5rem;
   margin-bottom: 0.75rem;
   color: var(--body-color);
   line-height: 1.25;
+  text-wrap: balance;
 }
 .section__lede {
   font-size: 1rem;             /* 16px */
@@ -125,22 +126,95 @@
 }
 .nav__cta { font-size: 0.875rem; }
 
+/* Hamburger toggle — hidden on desktop, shown at the mobile
+   breakpoint where the inline links collapse into a panel. */
+.nav__toggle {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  padding: 0;
+  border: 1px solid transparent;
+  border-radius: var(--radius);
+  background: transparent;
+  color: var(--body-color);
+  flex-shrink: 0;
+  transition: background-color 150ms ease, border-color 150ms ease;
+}
+.nav__toggle:hover {
+  background: var(--gray-100);
+  border-color: var(--border);
+}
+.nav__toggle:focus-visible {
+  outline: 2px solid var(--moodle-primary);
+  outline-offset: 2px;
+}
+
+/* Mobile menu panel — drops out of flow (fixed) so it never squeezes
+   the fixed-height navbar. Sits directly under the bar. */
+.nav__mobile {
+  position: fixed;
+  top: var(--navbar-h);
+  left: 0;
+  right: 0;
+  z-index: 99;
+  background: #fff;
+  border-bottom: 1px solid var(--border);
+  box-shadow: var(--shadow-md);
+}
+.nav__mobile-inner {
+  display: flex;
+  flex-direction: column;
+  padding-top: 0.5rem;
+  padding-bottom: 0.75rem;
+}
+.nav__mobile-inner a {
+  display: flex;
+  align-items: center;
+  min-height: 48px;
+  padding: 0 0.25rem;
+  color: var(--body-color);
+  font-size: 1rem;
+  font-weight: 500;
+  text-decoration: none;
+  border-bottom: 1px solid var(--border);
+}
+.nav__mobile-inner a:last-of-type { border-bottom: none; }
+.nav__mobile-inner a:active { color: var(--moodle-primary-hover); }
+.nav__mobile-license {
+  font-size: 0.8125rem;
+  color: var(--text-muted);
+  padding-top: 0.75rem;
+}
+
 @media (max-width: 720px) {
   .nav__links { display: none; }
   .nav__license { display: none; }
+  .nav__toggle { display: inline-flex; }
+  /* No inline links to push the right-hand group, so the brand claims
+     the free space instead. */
+  .nav__brand { margin-right: auto; }
+}
+
+/* Guarantee the panel and toggle never leak onto desktop, regardless
+   of the menu's open state when the viewport is resized. */
+@media (min-width: 721px) {
+  .nav__toggle,
+  .nav__mobile { display: none; }
 }
 
 /* ===================== HERO (page-header) ===================== */
 .hero {
-  padding-top: calc(var(--navbar-h) + 2.5rem);
-  padding-bottom: 2.5rem;
+  padding-top: calc(var(--navbar-h) + clamp(1.5rem, 4vw, 2.5rem));
+  padding-bottom: clamp(1.75rem, 4vw, 2.5rem);
   background: #fff;
   border-bottom: 1px solid var(--border);
 }
 .hero__inner {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 2.5rem;
+  gap: clamp(1.75rem, 4vw, 2.5rem);
   align-items: center;
 }
 @media (max-width: 920px) {
@@ -158,16 +232,13 @@
   border: 1px solid var(--moodle-primary-lt);
 }
 .hero__title {
-  font-size: 2.5rem;
+  font-size: clamp(1.875rem, 5.5vw, 2.75rem);   /* fluid 30 → 44px */
   font-weight: 700;
   line-height: 1.15;
   letter-spacing: -0.01em;
   color: var(--body-color);
   margin: 0 0 1rem;
   text-wrap: balance;
-}
-@media (min-width: 992px) {
-  .hero__title { font-size: 2.75rem; }
 }
 .hero__hl { color: var(--moodle-primary-hover); }
 .hero__lede {
@@ -242,7 +313,13 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  /* Allow the grid track to shrink below the demo's intrinsic content
+     width — without this the chat header's min-content forces the
+     column wider than its share and the demo spills past the viewport
+     in the 920–1080px range. */
+  min-width: 0;
 }
+.hero__copy { min-width: 0; }
 
 /* ===================== DEMO (chat panel) ===================== */
 .demo-section {
@@ -271,6 +348,7 @@
 .demo__head {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;            /* wrap intrinsically when the card is narrow */
   gap: 0.75rem;
   padding: 0.75rem 1rem;
   border-bottom: 1px solid var(--border);
@@ -519,6 +597,22 @@
 .demo--compact .demo__messages { min-height: 240px; max-height: 320px; }
 .demo--compact .demo__raw { min-height: 240px; max-height: 320px; }
 
+/* Narrow phones — the demo header packs a logo, identity, a two-tab
+   switch and a reset button into one row. Below 560px that row runs
+   out of width, so we let it wrap and shrink the non-essential bits
+   instead of forcing a horizontal overflow inside the chat card. */
+@media (max-width: 560px) {
+  .demo__head {
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+  .demo__head-id { order: 1; flex: 1 1 60%; }
+  .demo__logo { order: 0; height: 28px; }
+  .demo__new-chat { order: 2; }
+  .demo__tabs { order: 3; flex: 1 1 100%; justify-content: center; }
+  .demo__msg { max-width: 100%; }
+}
+
 /* ===================== ARCHITECTURE (steps / flow) ===================== */
 .arch {
   background: var(--gray-100);
@@ -639,11 +733,17 @@
 .arch__node--llm    { border-color: var(--moodle-primary); }
 .arch__node--output { border-color: var(--moodle-success); }
 
-@media (max-width: 920px) {
-  .arch__diagram { height: 460px; }
-  /* On narrow screens we switch to a vertical stack and hide the
-     SVG — the old grid layout is recovered via the .arch__row
-     class. */
+/* The absolute SVG-coordinate layout needs ~1080px of canvas to fit
+   without overflowing (the right-most node sits at x:880 + 200px).
+   Below ~1110px viewport the container is narrower than that, so we
+   switch to a vertical stack and hide the SVG. height:auto lets the
+   stacked nodes set their own height instead of being clipped to a
+   fixed box. */
+@media (max-width: 1110px) {
+  .arch__diagram {
+    height: auto;
+    margin-top: 0.5rem;
+  }
   .arch__edges { display: none; }
   .arch__row { display: flex; flex-direction: column; }
   .arch__node-wrap {
@@ -654,6 +754,7 @@
     height: auto !important;
     margin-bottom: 0.5rem;
   }
+  .arch__node { min-height: 56px; }
 }
 
 /* ===================== PROGRESS (Before / After stepper) ===================== */
@@ -1122,14 +1223,14 @@
   background: #fff;
   border: 1px solid var(--border);
   border-radius: var(--radius);
-  padding: 2.5rem;
+  padding: clamp(1.5rem, 5vw, 2.5rem);
   text-align: center;
   max-width: 720px;
   margin: 0 auto;
   box-shadow: var(--shadow-sm);
 }
 .cta__title {
-  font-size: 1.75rem;
+  font-size: clamp(1.4rem, 4.5vw, 1.75rem);
   font-weight: 700;
   color: var(--body-color);
   margin: 0.5rem 0 1rem;

--- a/landing/src/components/Nav.jsx
+++ b/landing/src/components/Nav.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
-import { motion } from 'framer-motion'
+import { AnimatePresence, motion } from 'framer-motion'
+import { Menu, X } from 'lucide-react'
 import MoodleWordmark from './MoodleWordmark.jsx'
 import { GITHUB_REPO_URL } from '../data.js'
 
@@ -16,6 +17,7 @@ const LINKS = [
 
 export default function Nav() {
   const [scrolled, setScrolled] = useState(false)
+  const [open, setOpen] = useState(false)
 
   useEffect(() => {
     const onScroll = () => setScrolled(window.scrollY > 24)
@@ -23,6 +25,25 @@ export default function Nav() {
     window.addEventListener('scroll', onScroll, { passive: true })
     return () => window.removeEventListener('scroll', onScroll)
   }, [])
+
+  // Close the mobile menu on Escape and once the viewport grows past
+  // the mobile breakpoint — otherwise an open panel could linger as a
+  // ghost layer when the user rotates or resizes to desktop.
+  useEffect(() => {
+    if (!open) return undefined
+    const onKey = (e) => {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    const onResize = () => {
+      if (window.innerWidth > 720) setOpen(false)
+    }
+    window.addEventListener('keydown', onKey)
+    window.addEventListener('resize', onResize, { passive: true })
+    return () => {
+      window.removeEventListener('keydown', onKey)
+      window.removeEventListener('resize', onResize)
+    }
+  }, [open])
 
   return (
     <motion.header
@@ -37,6 +58,7 @@ export default function Nav() {
           className="nav__brand"
           data-cursor="wordmark"
           aria-label="Moodle AI Assistant — home"
+          onClick={() => setOpen(false)}
         >
           <MoodleWordmark className="nav__logo" />
           <span className="nav__badge">AI Assistant</span>
@@ -64,7 +86,46 @@ export default function Nav() {
             GitHub
           </a>
         </div>
+
+        <button
+          type="button"
+          className="nav__toggle"
+          aria-expanded={open}
+          aria-controls="nav-mobile"
+          aria-label={open ? 'Close navigation menu' : 'Open navigation menu'}
+          onClick={() => setOpen((o) => !o)}
+          data-cursor="link"
+        >
+          {open ? <X size={22} strokeWidth={2} /> : <Menu size={22} strokeWidth={2} />}
+        </button>
       </div>
+
+      <AnimatePresence>
+        {open && (
+          <motion.nav
+            id="nav-mobile"
+            className="nav__mobile"
+            aria-label="Primary mobile"
+            initial={{ opacity: 0, y: -8 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -8 }}
+            transition={{ duration: 0.2, ease: 'easeOut' }}
+          >
+            <div className="wrap nav__mobile-inner">
+              {LINKS.map((l) => (
+                <a
+                  key={l.href + l.label}
+                  href={l.href}
+                  onClick={() => setOpen(false)}
+                >
+                  {l.label}
+                </a>
+              ))}
+              <span className="nav__mobile-license">MIT License</span>
+            </div>
+          </motion.nav>
+        )}
+      </AnimatePresence>
     </motion.header>
   )
 }

--- a/landing/src/index.css
+++ b/landing/src/index.css
@@ -99,6 +99,10 @@ html {
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
   scroll-behavior: smooth;
+  /* Safety net: no element should be able to push the page wider than
+     the viewport. Root causes are fixed individually below, but this
+     guarantees no accidental horizontal scroll on any device. */
+  overflow-x: hidden;
 }
 
 body {
@@ -108,6 +112,7 @@ body {
   line-height: 1.5;
   color: var(--body-color);
   background: var(--body-bg);
+  overflow-x: hidden;
 }
 
 h1, h2, h3, h4, h5, h6 {
@@ -154,7 +159,7 @@ ul, ol { margin: 0; padding: 0; list-style: none; }
 }
 
 .section {
-  padding: 3rem 0;             /* tighter — Boost-ish, not 160px */
+  padding: clamp(2.25rem, 6vw, 3rem) 0;   /* fluid — tighter on phones */
 }
 .section--tight { padding: 2rem 0; }
 

--- a/proxy/package-lock.json
+++ b/proxy/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "moodle-proxy",
-  "version": "0.1.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "moodle-proxy",
-      "version": "0.1.0",
+      "version": "1.1.0",
       "dependencies": {
         "@fastify/compress": "^8.3.1",
         "@fastify/cors": "^11.2.0",

--- a/proxy/package.json
+++ b/proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moodle-proxy",
-  "version": "0.1.0",
+  "version": "1.1.0",
   "description": "AI-powered learning assistant for Moodle LMS — Clean Architecture, Fastify, Ollama, SQLite",
   "type": "module",
   "engines": {


### PR DESCRIPTION
- Nav: add accessible mobile hamburger menu (toggle + slide-down panel, 48px touch targets, Escape/resize close); links were previously hidden with no replacement below 720px
- Architecture diagram: stack vertically below 1110px and use height:auto to stop the fixed-px node layout from overflowing the viewport and clipping stacked nodes
- Chat demo header: flex-wrap intrinsically and reorder on narrow phones so it never forces horizontal overflow inside the card
- Hero/section/CTA: fluid typography and spacing via clamp(); min-width:0 on hero grid tracks so the demo can shrink with its column
- Add overflow-x:hidden safety net on html/body

Verified in headless Chromium: zero element overflow from 360–1440px, mobile menu opens/closes, build passes.

chore(proxy): bump version to 1.1.0